### PR TITLE
Almost done with some of the separate helper and test stuff

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -79,6 +79,7 @@ describe("App Component Tests", () => {
   });
 
   it("Displays user details after successful authentication", async () => {
+    // Set it to the dev environment so we get the different port
     global.fetch = jest.fn().mockResolvedValue(
       createFetchResponse({
         data: {
@@ -91,6 +92,21 @@ describe("App Component Tests", () => {
         },
       }),
     );
+
+    // Set the environment to development
+    Object.defineProperties(process.env, {
+      REACT_APP_API_DEV: {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      },
+    });
+
+    // Reset our imports so we can do one in the development environment
+    jest.resetModules();
+
+    // Import our mockContext again so we can use it with dev
+    const { mockContext } = await import("./test-utils/mocks/objects");
 
     const { baseElement } = renderWithContext(<App />, { route: "/" }, mockContext);
 

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -27,12 +27,12 @@ exports[`App Component Tests Displays user details after successful authenticati
         <p
           class="app__text"
         >
-          Session created : 2026/04/23 22:53:17
+          Session created : 2026/04/24 20:47:41
         </p>
         <p
           class="app__text"
         >
-          Session expires : 2026/05/07 22:53:17
+          Session expires : 2026/05/08 20:47:41
         </p>
       </div>
     </div>

--- a/src/pages/Posts/CreatePost.test.tsx
+++ b/src/pages/Posts/CreatePost.test.tsx
@@ -56,8 +56,6 @@ beforeEach(() => {
   // Type cast mock to work as a regular fetch but using jest instead
   mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
   global.fetch = mockFetch;
-  // Mock our API requests between tests
-  jest.clearAllMocks();
 
   // Mock the result, and then mock the behavior that occurs if useNavigate is called
   mockNavigate = jest.fn();
@@ -71,7 +69,6 @@ beforeEach(() => {
     writable: true,
   });
 
-  jest.resetModules();
   // Create a new copy of process.env so we an update it
   process.env = { ...originalEnv };
 });
@@ -79,7 +76,6 @@ beforeEach(() => {
 // Cleanup mocks and environment
 afterEach(() => {
   clearAuthStorage();
-  jest.clearAllMocks();
   // Reset our process variable
   process.env = originalEnv;
 });

--- a/src/util/file.ts
+++ b/src/util/file.ts
@@ -24,14 +24,12 @@ export const generateBase64FromImage = (imageFile: File) => {
   const reader = new FileReader();
 
   // Read the file and encode it in base 64
-  const promise = new Promise((resolve, reject) => {
+  const promise = new Promise((resolve) => {
     reader.onload = (event: ProgressEvent<FileReader>) => {
       if (event.target) {
         resolve(event.target.result);
       }
     };
-
-    reader.onerror = (err) => reject(err);
   });
 
   reader.readAsDataURL(imageFile);


### PR DESCRIPTION
We don't need the reader.onError for now as we're error handling in CreatePost, but really, we should error handle in the method itself

I've removed reader.onError for now for this reason, but this solution actually isn't very scalable